### PR TITLE
List all conditions identifying match in docs

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -55,10 +55,12 @@ Inspired by the [Gotoh algorithm
 (pdf)](http://www.cs.unibo.it/~dilena/LabBII/Papers/AffineGaps.pdf), fzy
 computes a second `D` (for diagonal) matrix in parallel with the score matrix.
 The `D` matrix computes the best score which *ends* in a match. This allows
-both computation of the penlalty for starting a gap and the score for a
+both computation of the penalty for starting a gap and the score for a
 consecutive match.
 
-Using this algorithm fzy is able to score based on the optimal match.
+Using [this 
+algorithm](https://github.com/jhawthorn/fzy/blob/master/src/match.c#L58) fzy 
+is able to score based on the optimal match.
 
 * Gaps (negative score)
   * at the start of the match
@@ -67,8 +69,8 @@ Using this algorithm fzy is able to score based on the optimal match.
 * Matches (positive score)
   * consecutive
   * following a slash
-  * following a space (the start of a word)
-  * capital letter (the start of a CamlCase word)
+  * following a space, underscore, dash, or number (the start of a word)
+  * capital letter (the start of a CamelCase word)
   * following a dot (often a file extension)
 
 


### PR DESCRIPTION
I spent a fair bit of time comparing the sort order for different fuzzy finders before finding fzy. As it stands, I feared that weight wasn't given to underscore delimited (snake_case) or dash delimited (sausage-case) words. Fortunately, fzy does precisely what I want, so I wanted to update the docs. 

The positive weights are both intuitive and clearly explained. However, while I understand how a a gap *within* a match gives a sorting penalty, I am less clear how a gap before or after would affect the match. Is this just to ensure that perfect matches always receive the highest weight? Perhaps some examples would make this more clear.

Thanks so very much for building fzy!