### PR TITLE
Add sys/select.h to fix building with musl libc

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -5,6 +5,7 @@
 #include <stdarg.h>
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 
 #include "tty.h"
 


### PR DESCRIPTION
hi,

This patch is needed since commit d9924b1eb8a80bc642340227aa92f276c3ac1d5d which added the `tty_input_ready` function using `fd_set` and other things defined in `sys/select.h`.

Cheers,
Duncan