### PR TITLE
[WIP] Cursor movement in tty

### DIFF
--- a/src/tty_interface.h
+++ b/src/tty_interface.h
@@ -18,6 +18,7 @@ typedef struct {
 	char input[32]; /* Pending input buffer */
 
 	int exit;
+	int cursor;
 } tty_interface_t;
 
 void tty_interface_init(tty_interface_t *state, tty_t *tty, choices_t *choices, options_t *options);


### PR DESCRIPTION
Hi, I really like this awesome fuzzy finder!

I added cursor member to `tty_interface_t` struct to implement cursor movement.

Like this:

<img src="https://cloud.githubusercontent.com/assets/4442708/19794813/6e8bf2be-9d10-11e6-882c-50f0fb6f81fa.gif" width="300">

Support keybindings: Ctrl-A,Ctrl-E,`←`,`→`

TODO:
- [ ] append search (in string)
- [ ] delete char (in string)

How do you feel about this feature and implementation?
