### PR TITLE
exit on escape

### DIFF
--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -227,7 +227,7 @@ static const keybinding_t keybindings[] = {{"\x7f", action_del_char},	/* DEL */
 					   {KEY_CTRL('M'), action_emit},	 /* CR */
 					   {KEY_CTRL('P'), action_prev},	 /* C-P */
 					   {KEY_CTRL('N'), action_next},	 /* C-N */
-
+					   {"\x1b",   action_exit}, /* ESC */
 					   {"\x1b[A", action_prev}, /* UP */
 					   {"\x1bOA", action_prev}, /* UP */
 					   {"\x1b[B", action_next}, /* DOWN */


### PR DESCRIPTION
Hello,
first of all, thank you for this wonderful software!

It's a simple pull request to add ESC as exit keybinding in addition to CTLR+D.
I'm not sure if you like that idea or there any conflicts with other tools used in conjunction with fzy, it just fits nicely into my workflow and of course I'm just lazy to patch it every time.
I moved to fzy from peco, it exits on escape.

Thanks and good luck!