### PR TITLE
Add new option 'all' to output all matches

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -10,6 +10,7 @@ static const char *usage_str =
     ""
     "Usage: fzy [OPTION]...\n"
     " -l, --lines=LINES        Specify how many lines of results to show (default 10)\n"
+	" -a, --all                Print all matched lines\n"
     " -p, --prompt=PROMPT      Input prompt (default '> ')\n"
     " -q, --query=QUERY        Use QUERY as the initial search string\n"
     " -e, --show-matches=QUERY Output the sorted matches of QUERY\n"
@@ -26,6 +27,7 @@ static void usage(const char *argv0) {
 static struct option longopts[] = {{"show-matches", required_argument, NULL, 'e'},
 				   {"query", required_argument, NULL, 'q'},
 				   {"lines", required_argument, NULL, 'l'},
+				   {"all", no_argument, NULL, 'a'},
 				   {"tty", required_argument, NULL, 't'},
 				   {"prompt", required_argument, NULL, 'p'},
 				   {"show-scores", no_argument, NULL, 's'},
@@ -43,6 +45,7 @@ void options_init(options_t *options) {
 	options->tty_filename = "/dev/tty";
 	options->show_scores = 0;
 	options->num_lines = 10;
+	options->output_all = 0;
 	options->scrolloff = 1;
 	options->prompt = "> ";
 	options->workers = 0;
@@ -52,7 +55,7 @@ void options_parse(options_t *options, int argc, char *argv[]) {
 	options_init(options);
 
 	int c;
-	while ((c = getopt_long(argc, argv, "vhse:q:l:t:p:j:", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "vhsae:q:l:t:p:j:", longopts, NULL)) != -1) {
 		switch (c) {
 			case 'v':
 				printf("%s " VERSION " (c) 2014 John Hawthorn\n", argv[0]);
@@ -87,6 +90,9 @@ void options_parse(options_t *options, int argc, char *argv[]) {
 					usage(argv[0]);
 					exit(EXIT_FAILURE);
 				}
+				break;
+			case 'a':
+				options->output_all = 1;
 				break;
 			case 'l': {
 				int l;

--- a/src/options.h
+++ b/src/options.h
@@ -8,6 +8,7 @@ typedef struct {
 	const char *tty_filename;
 	int show_scores;
 	unsigned int num_lines;
+	unsigned int output_all;
 	unsigned int scrolloff;
 	const char *prompt;
 	unsigned int workers;

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -118,13 +118,18 @@ static void action_emit(tty_interface_t *state) {
 	/* ttyout should be flushed before outputting on stdout */
 	tty_close(state->tty);
 
-	const char *selection = choices_get(state->choices, state->choices->selection);
-	if (selection) {
-		/* output the selected result */
-		printf("%s\n", selection);
-	} else {
-		/* No match, output the query instead */
-		printf("%s\n", state->search);
+	unsigned int all = state->options->output_all;
+	size_t start     = all ? 0 : state->choices->selection;
+	size_t end       = all ? choices_available(state->choices) : start + 1;
+	for (size_t i = start; i < end; i++) {
+		const char *selection = choices_get(state->choices, i);
+		if (selection) {
+			/* output the selected result */
+			printf("%s\n", selection);
+		} else {
+			/* No match, output the query instead */
+			printf("%s\n", state->search);
+		}
 	}
 
 	state->exit = EXIT_SUCCESS;


### PR DESCRIPTION
This commit adds the option '--all' / '-a', which will cause fzy to
ignore the selection and output all matching lines on return.

I needed this feature so I could call fzy from vim and fill a location-list with the output. I just found fzy today and was pleasantly surprised by how clean the code base is and how easy it was to add  new functionality, so I just wrote this small patch. There might be better ways to solve this, possibly without changing fzy. Feel free to reject this PR and point me in a different direction in that case.