### PR TITLE
README.md: gentoo now has fzy ebuild, document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ fzy is available in the `community` repo.
 
     sudo pacman -S fzy
 
+### Gentoo Linux
+
+fzy is available in the main repo.
+
+    emerge -av app-shells/fzy
+
 ### pkgsrc (NetBSD and others)
 
     sudo pkgin install fzy


### PR DESCRIPTION
Hi,

I've recently added fzy to https://github.com/gentoo/gentoo/commit/b0bc8f3423f46fc5f189a91fd778bfd794b07d15. Let's have it documented for discoverability.