### PR TITLE
[RFC] tty_interface: If backspace is pressed on empty input, exit

### DIFF
--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -132,6 +132,13 @@ static void action_emit(tty_interface_t *state) {
 	state->exit = EXIT_SUCCESS;
 }
 
+static void action_exit(tty_interface_t *state) {
+	clear(state);
+	tty_close(state->tty);
+
+	state->exit = EXIT_FAILURE;
+}
+
 static void action_del_char(tty_interface_t *state) {
 	if (*state->search) {
 		size_t length = strlen(state->search);
@@ -141,6 +148,8 @@ static void action_del_char(tty_interface_t *state) {
 
 		state->cursor--;
 		memmove(&state->search[state->cursor], &state->search[state->cursor + 1], length - state->cursor);
+	} else {
+		action_exit(state);
 	}
 }
 
@@ -214,13 +223,6 @@ static void action_autocomplete(tty_interface_t *state) {
 		strncpy(state->search, choices_get(state->choices, state->choices->selection), SEARCH_SIZE_MAX);
 		state->cursor = strlen(state->search);
 	}
-}
-
-static void action_exit(tty_interface_t *state) {
-	clear(state);
-	tty_close(state->tty);
-
-	state->exit = EXIT_FAILURE;
 }
 
 static void append_search(tty_interface_t *state, char ch) {


### PR DESCRIPTION
This is how the : prompt in vim handles backspace on empty input, so it
feels convenient for me.

This patch may be bad for people who press backspace repeatedly to clear
the input line, and then accidentally press backspace once too often,
and exit fzy, so maybe it should be placed behind a command line option.
(I use ^U when I want to clear the input line, so this doesn't happen to me.)