### PR TITLE
Abort on Esc

### DIFF
--- a/fzy.1
+++ b/fzy.1
@@ -54,6 +54,9 @@ Usage help.
 .BR "ENTER"
 Print the selected item to stdout and exit
 .TP
+.BR "Ctrl+c, Esc"
+Abort selecting and exit
+.TP
 .BR "Up Arrow, Ctrl+p"
 Select the previous item
 .TP

--- a/src/tty.c
+++ b/src/tty.c
@@ -90,6 +90,7 @@ char tty_getchar(tty_t *tty) {
 int tty_input_ready(tty_t *tty) {
 	fd_set readfs;
 	struct timeval tv = {0, 0};
+	FD_ZERO(&readfs);
 	FD_SET(tty->fdin, &readfs);
 	select(tty->fdin + 1, &readfs, NULL, NULL, &tv);
 	return FD_ISSET(tty->fdin, &readfs);

--- a/src/tty.c
+++ b/src/tty.c
@@ -87,9 +87,9 @@ char tty_getchar(tty_t *tty) {
 	}
 }
 
-int tty_input_ready(tty_t *tty) {
+int tty_input_ready(tty_t *tty, int pending) {
 	fd_set readfs;
-	struct timeval tv = {0, 0};
+	struct timeval tv = {0, pending ? 500000 : 0};
 	FD_ZERO(&readfs);
 	FD_SET(tty->fdin, &readfs);
 	select(tty->fdin + 1, &readfs, NULL, NULL, &tv);

--- a/src/tty.h
+++ b/src/tty.h
@@ -17,7 +17,7 @@ void tty_close(tty_t *tty);
 void tty_init(tty_t *tty, const char *tty_filename);
 void tty_getwinsz(tty_t *tty);
 char tty_getchar(tty_t *tty);
-int tty_input_ready(tty_t *tty);
+int tty_input_ready(tty_t *tty, int pending);
 
 void tty_setfg(tty_t *tty, int fg);
 void tty_setinvert(tty_t *tty);

--- a/src/tty_interface.h
+++ b/src/tty_interface.h
@@ -16,6 +16,7 @@ typedef struct {
 	char last_search[SEARCH_SIZE_MAX + 1];
 	size_t cursor;
 
+	int ambiguous_key_pending;
 	char input[32]; /* Pending input buffer */
 
 	int exit;


### PR DESCRIPTION
* Maps Esc to `action_exit`
* Code to handle ambiguous mappings (with the same prefix), by waiting 1/2 second for a disambiguating character.
* Fix initialization of `fd_set`

And, thank you for this tool!

Related to #65 .