### PR TITLE
Initialize tty before reading choices 

### DIFF
--- a/src/fzy.c
+++ b/src/fzy.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <limits.h>
+#include <unistd.h>
 
 #include "match.h"
 #include "tty.h"
@@ -39,10 +40,15 @@ int main(int argc, char *argv[]) {
 		}
 	} else {
 		/* interactive */
+
+		if (isatty(STDIN_FILENO))
+			choices_fread(&choices, stdin);
+
 		tty_t tty;
 		tty_init(&tty, options.tty_filename);
 
-		choices_fread(&choices, stdin);
+		if (!isatty(STDIN_FILENO))
+			choices_fread(&choices, stdin);
 
 		if (options.num_lines > choices.size)
 			options.num_lines = choices.size;

--- a/src/fzy.c
+++ b/src/fzy.c
@@ -20,16 +20,17 @@ int main(int argc, char *argv[]) {
 
 	choices_t choices;
 	choices_init(&choices, &options);
-	choices_fread(&choices, stdin);
 
 	if (options.benchmark) {
 		if (!options.filter) {
 			fprintf(stderr, "Must specify -e/--show-matches with --benchmark\n");
 			exit(EXIT_FAILURE);
 		}
+		choices_fread(&choices, stdin);
 		for (int i = 0; i < options.benchmark; i++)
 			choices_search(&choices, options.filter);
 	} else if (options.filter) {
+		choices_fread(&choices, stdin);
 		choices_search(&choices, options.filter);
 		for (size_t i = 0; i < choices_available(&choices); i++) {
 			if (options.show_scores)
@@ -40,6 +41,8 @@ int main(int argc, char *argv[]) {
 		/* interactive */
 		tty_t tty;
 		tty_init(&tty, options.tty_filename);
+
+		choices_fread(&choices, stdin);
 
 		if (options.num_lines > choices.size)
 			options.num_lines = choices.size;

--- a/test/acceptance/acceptance_test.rb
+++ b/test/acceptance/acceptance_test.rb
@@ -320,6 +320,13 @@ class FzyTest < Minitest::Test
     @tty.assert_matches "> foo\nfoo"
   end
 
+  # https://github.com/jhawthorn/fzy/issues/81
+  def test_slow_stdin_fast_user
+    @tty = TTYtest.new_terminal(%{(echo aa; echo bc; echo bd; sleep 0.5) | #{FZY_PATH}})
+    @tty.send_keys("b\r")
+    @tty.assert_matches "bc"
+  end
+
   def test_help
     @tty = TTYtest.new_terminal(%{#{FZY_PATH} --help})
     @tty.assert_matches <<TTY


### PR DESCRIPTION
It's possible for user input to arrive while fzy was still reading choices from stdin. Previously, this would happen before the correct termios were set, causing fzy to misinterpret Enter as Ctrl-J for example.

Fixes #81