### PR TITLE
Add support for underlining selected item

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -110,6 +110,10 @@ void tty_setinvert(tty_t *tty) {
 	tty_sgr(tty, 7);
 }
 
+void tty_setunderline(tty_t *tty) {
+	tty_sgr(tty, 4);
+}
+
 void tty_setnormal(tty_t *tty) {
 	tty_sgr(tty, 0);
 	tty->fgcolor = 9;

--- a/src/tty.h
+++ b/src/tty.h
@@ -21,6 +21,7 @@ int tty_input_ready(tty_t *tty);
 
 void tty_setfg(tty_t *tty, int fg);
 void tty_setinvert(tty_t *tty);
+void tty_setunderline(tty_t *tty);
 void tty_setnormal(tty_t *tty);
 
 #define TTY_COLOR_BLACK 0

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -46,7 +46,11 @@ static void draw_match(tty_interface_t *state, const char *choice, int selected)
 	}
 
 	if (selected)
+#ifdef TTY_SELECTION_UNDERLINE
+		tty_setunderline(tty);
+#else
 		tty_setinvert(tty);
+#endif
 
 	for (size_t i = 0, p = 0; choice[i] != '\0'; i++) {
 		if (i + 1 < maxwidth) {


### PR DESCRIPTION
Tested and works with or without `#define`. No BC breaks since we're checking `#ifdef`.

Helps my eye strain a lot with this tool!

Will fix #87 