### PR TITLE
Add Note About OS X Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ nnoremap <leader>v :call FzyCommand("find -type f", ":vs")<cr>
 nnoremap <leader>s :call FzyCommand("find -type f", ":sp")<cr>
 ```
 
+Note: OS X users may need to use ```find . -type f` instead of `find -type f`.
+
+
 Any program can be used to filter files presented through fzy. [ag (the silver searcher)](https://github.com/ggreer/the_silver_searcher) can be used to ignore files specified by `.gitignore`.
 
 ``` vim
@@ -114,3 +117,4 @@ It prefers shorter candidates: `test` matches <tt><b>test</b>s</tt> over <tt><b>
 
 * [fzy.js](https://github.com/jhawthorn/fzy.js) Javascript port
 
+    


### PR DESCRIPTION
While I was installing this on my OS X High Sierra installation, I ran
into an issue with the `find` command. On OS X you need to provide
`find` with a path.
I'm sure this is something that devs would eventually figure out on
their own, but it I feel is could stand to be in the README too.