### PR TITLE
split lines to choice and parameter part (with -d/--separator option)

### DIFF
--- a/src/choices.h
+++ b/src/choices.h
@@ -8,7 +8,7 @@
 
 struct scored_result {
 	score_t score;
-	const char *str;
+	size_t str;
 };
 
 typedef struct {
@@ -19,21 +19,24 @@ typedef struct {
 	size_t size;
 
 	const char **strings;
+	const char **strings_param;
 	struct scored_result *results;
 
 	size_t available;
 	size_t selection;
 
 	unsigned int worker_count;
+	char separator;
 } choices_t;
 
 void choices_init(choices_t *c, options_t *options);
 void choices_fread(choices_t *c, FILE *file);
 void choices_destroy(choices_t *c);
-void choices_add(choices_t *c, const char *choice);
+void choices_add(choices_t *c, char *line);
 size_t choices_available(choices_t *c);
 void choices_search(choices_t *c, const char *search);
 const char *choices_get(choices_t *c, size_t n);
+const char *choices_get_param(choices_t *c, size_t n);
 score_t choices_getscore(choices_t *c, size_t n);
 void choices_prev(choices_t *c);
 void choices_next(choices_t *c);

--- a/src/options.c
+++ b/src/options.c
@@ -17,7 +17,7 @@ static const char *usage_str =
     " -e, --show-matches=QUERY Output the sorted matches of QUERY\n"
     " -t, --tty=TTY            Specify file to use as TTY device (default /dev/tty)\n"
     " -s, --show-scores        Show the scores of each match\n"
-    " -j, --workers NUM        Use NUM workers for searching. (default is # of CPUs)\n"
+    " -j, --workers=NUM        Use NUM workers for searching (default is # of CPUs)\n"
     " -h, --help     Display this help and exit\n"
     " -v, --version  Output version information and exit\n";
 

--- a/src/options.c
+++ b/src/options.c
@@ -18,6 +18,7 @@ static const char *usage_str =
     " -t, --tty=TTY            Specify file to use as TTY device (default /dev/tty)\n"
     " -s, --show-scores        Show the scores of each match\n"
     " -j, --workers=NUM        Use NUM workers for searching (default is # of CPUs)\n"
+    " -d, --separator=SEP      Use SEP to split the line to the searchable part and the rest\n"
     " -h, --help     Display this help and exit\n"
     " -v, --version  Output version information and exit\n";
 
@@ -34,6 +35,7 @@ static struct option longopts[] = {{"show-matches", required_argument, NULL, 'e'
 				   {"version", no_argument, NULL, 'v'},
 				   {"benchmark", optional_argument, NULL, 'b'},
 				   {"workers", required_argument, NULL, 'j'},
+				   {"separator", required_argument, NULL, 'd'},
 				   {"help", no_argument, NULL, 'h'},
 				   {NULL, 0, NULL, 0}};
 
@@ -48,13 +50,14 @@ void options_init(options_t *options) {
 	options->num_lines    = DEFAULT_NUM_LINES;
 	options->prompt       = DEFAULT_PROMPT;
 	options->workers      = DEFAULT_WORKERS;
+	options->separator    = 0;
 }
 
 void options_parse(options_t *options, int argc, char *argv[]) {
 	options_init(options);
 
 	int c;
-	while ((c = getopt_long(argc, argv, "vhse:q:l:t:p:j:", longopts, NULL)) != -1) {
+	while ((c = getopt_long(argc, argv, "vhse:q:l:t:p:j:d:", longopts, NULL)) != -1) {
 		switch (c) {
 			case 'v':
 				printf("%s " VERSION " © 2014-2018 John Hawthorn\n", argv[0]);
@@ -86,6 +89,12 @@ void options_parse(options_t *options, int argc, char *argv[]) {
 				break;
 			case 'j':
 				if (sscanf(optarg, "%u", &options->workers) != 1) {
+					usage(argv[0]);
+					exit(EXIT_FAILURE);
+				}
+				break;
+			case 'd':
+				if (sscanf(optarg, "%c", &options->separator) != 1) {
 					usage(argv[0]);
 					exit(EXIT_FAILURE);
 				}

--- a/src/options.h
+++ b/src/options.h
@@ -11,6 +11,7 @@ typedef struct {
 	unsigned int scrolloff;
 	const char *prompt;
 	unsigned int workers;
+	char separator;
 } options_t;
 
 void options_init(options_t *options);

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -131,8 +131,17 @@ static void action_emit(tty_interface_t *state) {
 
 	const char *selection = choices_get(state->choices, state->choices->selection);
 	if (selection) {
-		/* output the selected result */
-		printf("%s\n", selection);
+		/* Output the selected result */
+		if (state->options->separator) {
+			const char *selection_param = choices_get_param(state->choices, state->choices->selection);
+			if (selection_param) {
+				printf("%s%c%s\n", selection, state->options->separator, selection_param);
+			} else {
+				printf("%s\n", selection);
+			}
+		} else {
+			printf("%s\n", selection);
+		}
 	} else {
 		/* No match, output the query instead */
 		printf("%s\n", state->search);

--- a/test/acceptance/acceptance_test.rb
+++ b/test/acceptance/acceptance_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'minitest'
 require 'minitest/autorun'
 require 'ttytest'
@@ -456,7 +457,9 @@ Usage: fzy [OPTION]...
  -e, --show-matches=QUERY Output the sorted matches of QUERY
  -t, --tty=TTY            Specify file to use as TTY device (default /dev/tty)
  -s, --show-scores        Show the scores of each match
- -j, --workers NUM        Use NUM workers for searching. (default is # of CPUs)
+ -j, --workers=NUM        Use NUM workers for searching (default is # of CPUs)
+ -d, --separator=SEP      Use SEP to split the line to the searchable part and t
+he rest
  -h, --help     Display this help and exit
  -v, --version  Output version information and exit
 TTY


### PR DESCRIPTION
Add -d/--separator option to specify separator char that is used to split the line to searchable part and extra parameter part. The query applies only to the searchable part. The corresponding extra parameter is added to the selected result.

In example, "cat /etc/passwd | fzy -d:" will display and match only usernames and when you select one the output would be the complete corresponding passwd file line.

Note, currently the first field is always searchable but it wont be hard to add another option to choose specifiec field number for that (aka cut-like functionality). 