### PR TITLE
Fix 6 missing dependencies and 1 excessive dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,15 +31,15 @@ check: test/fzytest
 fzy: $(OBJECTS)
 	$(CC) $(CFLAGS) $(CCFLAGS) -o $@ $(OBJECTS) $(LIBS)
 
-%.o: %.c config.h
+%.o: %.c 
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
-src/fzy.o: src/tty_interface.h src/match.h src/tty.h src/options.h src/choices.h
-src/match.o: src/bonus.h src/match.h
-src/tty.o: src/tty.h
+src/fzy.o: src/tty_interface.h src/match.h src/tty.h src/options.h src/choices.h config.h
+src/match.o: src/bonus.h src/match.h config.h
+src/tty.o: src/tty.h config.h
 src/choices.o: src/options.h src/match.h src/choices.h
-src/options.o: src/options.h
-src/tty_interface.o: src/options.h src/tty_interface.h src/match.h src/tty.h src/choices.h
+src/options.o: src/options.h config.h
+src/tty_interface.o: src/options.h src/tty_interface.h src/match.h src/tty.h src/choices.h config.h
 
 config.h: src/config.def.h
 	cp src/config.def.h config.h

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ fzy: $(OBJECTS)
 %.o: %.c config.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
+src/fzy.o: src/tty_interface.h src/match.h src/tty.h src/options.h src/choices.h
+src/match.o: src/bonus.h src/match.h
+src/tty.o: src/tty.h
+src/choices.o: src/options.h src/match.h src/choices.h
+src/options.o: src/options.h
+src/tty_interface.o: src/options.h src/tty_interface.h src/match.h src/tty.h src/choices.h
+
 config.h: src/config.def.h
 	cp src/config.def.h config.h
 


### PR DESCRIPTION
Hi, I've fixed 6 dependencies missing and 1 dependency excessive reported.
Those issues can cause incorrect results when fzy is incrementally built.
For example, any changes in "src/tty_interface.h" will not cause "src/fzy.o" to be rebuilt, which is incorrect. The changes in "config.h" will cause an unnecessary rebuild of "src/choices.o".
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

Thanks
Vemake