### PR TITLE
Prefer trailing matches over start of words

### DIFF
--- a/test/acceptance/acceptance_test.rb
+++ b/test/acceptance/acceptance_test.rb
@@ -239,7 +239,7 @@ class FzyTest < Minitest::Test
     @tty.send_keys('foo')
     @tty.assert_matches "> foo\n#{expected_score} foo"
 
-    expected_score = '( 0.89)'
+    expected_score = '( 0.99)'
     @tty = interactive_fzy(input: %w[foo bar], args: "-s")
     @tty.send_keys('f')
     @tty.assert_matches "> f\n#{expected_score} foo"
@@ -248,10 +248,10 @@ class FzyTest < Minitest::Test
   def test_large_input
     @tty = TTYtest.new_terminal(%{seq 100000 | #{FZY_PATH} -l 3})
     @tty.send_keys('34')
-    @tty.assert_matches "> 34\n34\n340\n341"
+    @tty.assert_matches "> 34\n34\n134\n234"
 
     @tty.send_keys('5')
-    @tty.assert_matches "> 345\n345\n3450\n3451"
+    @tty.assert_matches "> 345\n345\n1345\n2345"
 
     @tty.send_keys('z')
     @tty.assert_matches "> 345z"
@@ -264,11 +264,11 @@ class FzyTest < Minitest::Test
 
     @tty = TTYtest.new_terminal(%{seq 100000 | #{FZY_PATH} -j1 -l3})
     @tty.send_keys('34')
-    @tty.assert_matches "> 34\n34\n340\n341"
+    @tty.assert_matches "> 34\n34\n134\n234"
 
     @tty = TTYtest.new_terminal(%{seq 100000 | #{FZY_PATH} -j200 -l3})
     @tty.send_keys('34')
-    @tty.assert_matches "> 34\n34\n340\n341"
+    @tty.assert_matches "> 34\n34\n134\n234"
   end
 
   def test_initial_query

--- a/test/test_choices.c
+++ b/test/test_choices.c
@@ -63,8 +63,8 @@ TEST test_choices_1() {
 }
 
 TEST test_choices_2() {
-	choices_add(&choices, "tags");
 	choices_add(&choices, "test");
+	choices_add(&choices, "tags");
 
 	/* Empty search */
 	choices_search(&choices, "");
@@ -102,8 +102,8 @@ TEST test_choices_2() {
 	choices_search(&choices, "ts");
 	ASSERT_SIZE_T_EQ(2, choices.available);
 	ASSERT_SIZE_T_EQ(0, choices.selection);
-	ASSERT_STR_EQ("test", choices_get(&choices, 0));
-	ASSERT_STR_EQ("tags", choices_get(&choices, 1));
+	ASSERT_STR_EQ("tags", choices_get(&choices, 0));
+	ASSERT_STR_EQ("test", choices_get(&choices, 1));
 
 	PASS();
 }


### PR DESCRIPTION
Count a match at the beginning and end of the candidate as a consecutive
match. With that fzy returns better results, when searching for file
extensions, e.g. when searching for "appc", it scores "src/app.c" higher
than "build/app/contents/cache".

A match at the beginning was scored with the same bonus as a character
after a slash. To keep it consistent, this is now scored as a
consecutive match.

Another, more practical example from the tmux source tree:
`$ find . -type f | fzy -se tmuxh` without the patch returned:
```
4.570000        ./logo/tmux-logo-huge.png
4.480000        ./tmux.h
```
With the patch you get a more intuitive result:
```
5.480000        ./tmux.h
4.570000        ./logo/tmux-logo-huge.png
```
If you really wanted the .png, you could continue typing and refine the
search, but if you wanted the header file without the patch, you cannot
type an end of line character to filter the results further.

Note that I had to change some test cases, which broke with this change,
but I still prefer the new behavior. Let me know, if you find a case,
which is counter intuitive.