### PR TITLE
Avoid use of VLA and reduce memory usage in match to O(m)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.0
 
 CPPFLAGS=-DVERSION=\"${VERSION}\" -D_GNU_SOURCE
-CFLAGS+=-Wall -Wextra -g -std=c99 -O3 -pedantic -Ideps
+CFLAGS+=-Wall -Wextra -g -std=c99 -O3 -pedantic -Ideps -Werror=vla
 PREFIX?=/usr/local
 MANDIR?=$(PREFIX)/share/man
 BINDIR?=$(PREFIX)/bin

--- a/src/match.c
+++ b/src/match.c
@@ -186,7 +186,9 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	 * D[][] Stores the best score for this position ending with a match.
 	 * M[][] Stores the best possible score at this position.
 	 */
-	score_t D[n][m], M[n][m];
+	score_t (*D)[MATCH_MAX_LEN], (*M)[MATCH_MAX_LEN];
+	M = malloc(sizeof(score_t) * MATCH_MAX_LEN * n);
+	D = malloc(sizeof(score_t) * MATCH_MAX_LEN * n);
 
 	score_t *last_D, *last_M;
 	score_t *curr_D, *curr_M;
@@ -230,5 +232,10 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		}
 	}
 
-	return M[n - 1][m - 1];
+	score_t result = M[n - 1][m - 1];
+
+	free(M);
+	free(D);
+
+	return result;
 }

--- a/src/match.c
+++ b/src/match.c
@@ -83,9 +83,7 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		 * just be ranked below any reasonably sized candidates
 		 */
 		return SCORE_MIN;
-	}
-
-	if (n == m) {
+	} else if (n == m) {
 		/* Since this method can only be called with a haystack which
 		 * matches needle. If the lengths of the strings are equal the
 		 * strings themselves must also be equal (ignoring case).

--- a/src/match.c
+++ b/src/match.c
@@ -46,9 +46,8 @@ struct match_struct {
 
 static void precompute_bonus(const char *haystack, score_t *match_bonus) {
 	/* Which positions are beginning of words */
-	int m = strlen(haystack);
 	char last_ch = '/';
-	for (int i = 0; i < m; i++) {
+	for (int i = 0; haystack[i]; i++) {
 		char ch = haystack[i];
 		match_bonus[i] = COMPUTE_BONUS(last_ch, ch);
 		last_ch = ch;

--- a/src/match.c
+++ b/src/match.c
@@ -28,6 +28,8 @@ int has_match(const char *needle, const char *haystack) {
 	return 1;
 }
 
+#define SWAP(x, y, T) do { T SWAP = x; x = y; y = SWAP; } while (0)
+
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
 #ifdef DEBUG_VERBOSE
@@ -159,22 +161,24 @@ score_t match(const char *needle, const char *haystack) {
 	 * D[][] Stores the best score for this position ending with a match.
 	 * M[][] Stores the best possible score at this position.
 	 */
-	score_t D[n][m], M[n][m];
+	score_t D[2][MATCH_MAX_LEN], M[2][MATCH_MAX_LEN];
 
 	score_t *last_D, *last_M;
 	score_t *curr_D, *curr_M;
 
-	for (int i = 0; i < n; i++) {
-		curr_D = &D[i][0];
-		curr_M = &M[i][0];
+	last_D = D[0];
+	last_M = M[0];
+	curr_D = D[1];
+	curr_M = M[1];
 
+	for (int i = 0; i < n; i++) {
 		match_row(&match, i, curr_D, curr_M, last_D, last_M);
 
-		last_D = curr_D;
-		last_M = curr_M;
+		SWAP(curr_D, last_D, score_t *);
+		SWAP(curr_M, last_M, score_t *);
 	}
 
-	return M[n - 1][m - 1];
+	return last_M[m - 1];
 }
 
 score_t match_positions(const char *needle, const char *haystack, size_t *positions) {

--- a/src/match.c
+++ b/src/match.c
@@ -105,7 +105,7 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	for (int i = 0; i < m; i++)
 		lower_haystack[i] = tolower(haystack[i]);
 
-	score_t match_bonus[m];
+	score_t match_bonus[MATCH_MAX_LEN];
 	score_t D[n][m], M[n][m];
 
 	/*

--- a/src/match.c
+++ b/src/match.c
@@ -108,6 +108,9 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	score_t match_bonus[MATCH_MAX_LEN];
 	score_t D[n][m], M[n][m];
 
+	score_t *last_D, *last_M;
+	score_t *curr_D, *curr_M;
+
 	/*
 	 * D[][] Stores the best score for this position ending with a match.
 	 * M[][] Stores the best possible score at this position.
@@ -118,6 +121,9 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		score_t prev_score = SCORE_MIN;
 		score_t gap_score = i == n - 1 ? SCORE_GAP_TRAILING : SCORE_GAP_INNER;
 
+		curr_D = &D[i][0];
+		curr_M = &M[i][0];
+
 		for (int j = 0; j < m; j++) {
 			if (lower_needle[i] == lower_haystack[j]) {
 				score_t score = SCORE_MIN;
@@ -125,18 +131,21 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 					score = (j * SCORE_GAP_LEADING) + match_bonus[j];
 				} else if (j) { /* i > 0 && j > 0*/
 					score = max(
-					    M[i - 1][j - 1] + match_bonus[j],
+					    last_M[j - 1] + match_bonus[j],
 
 					    /* consecutive match, doesn't stack with match_bonus */
-					    D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE);
+					    last_D[j - 1] + SCORE_MATCH_CONSECUTIVE);
 				}
-				D[i][j] = score;
-				M[i][j] = prev_score = max(score, prev_score + gap_score);
+				curr_D[j] = score;
+				curr_M[j] = prev_score = max(score, prev_score + gap_score);
 			} else {
-				D[i][j] = SCORE_MIN;
-				M[i][j] = prev_score = prev_score + gap_score;
+				curr_D[j] = SCORE_MIN;
+				curr_M[j] = prev_score = prev_score + gap_score;
 			}
 		}
+
+		last_D = curr_D;
+		last_M = curr_M;
 	}
 
 #ifdef DEBUG_VERBOSE

--- a/src/match.c
+++ b/src/match.c
@@ -32,33 +32,6 @@ int has_match(const char *needle, const char *haystack) {
 
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
-#ifdef DEBUG_VERBOSE
-/* print one of the internal matrices */
-void mat_print(score_t *mat, char name, const char *needle, const char *haystack) {
-	int n = strlen(needle);
-	int m = strlen(haystack);
-	int i, j;
-	fprintf(stderr, "%c   ", name);
-	for (j = 0; j < m; j++) {
-		fprintf(stderr, "     %c", haystack[j]);
-	}
-	fprintf(stderr, "\n");
-	for (i = 0; i < n; i++) {
-		fprintf(stderr, " %c |", needle[i]);
-		for (j = 0; j < m; j++) {
-			score_t val = mat[i * m + j];
-			if (val == SCORE_MIN) {
-				fprintf(stderr, "    -\u221E");
-			} else {
-				fprintf(stderr, " %.3f", val);
-			}
-		}
-		fprintf(stderr, "\n");
-	}
-	fprintf(stderr, "\n\n");
-}
-#endif
-
 #define MATCH_MAX_LEN 1024
 
 struct match_struct {
@@ -227,13 +200,6 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		last_D = curr_D;
 		last_M = curr_M;
 	}
-
-#ifdef DEBUG_VERBOSE
-	fprintf(stderr, "\"%s\" =~ \"%s\"\n", needle, haystack);
-	mat_print(&D[0][0], 'D', needle, haystack);
-	mat_print(&M[0][0], 'M', needle, haystack);
-	fprintf(stderr, "\n");
-#endif
 
 	/* backtrace to find the positions of optimal matching */
 	if (positions) {

--- a/src/match.c
+++ b/src/match.c
@@ -76,7 +76,7 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	int n = strlen(needle);
 	int m = strlen(haystack);
 
-	if (m > MATCH_MAX_LEN || n > MATCH_MAX_LEN) {
+	if (m > MATCH_MAX_LEN || n > m) {
 		/*
 		 * Unreasonably large candidate: return no score
 		 * If it is a valid match it will still be returned, it will

--- a/src/match.c
+++ b/src/match.c
@@ -56,6 +56,8 @@ void mat_print(score_t *mat, char name, const char *needle, const char *haystack
 }
 #endif
 
+#define MATCH_MAX_LEN 1024
+
 static void precompute_bonus(const char *haystack, score_t *match_bonus) {
 	/* Which positions are beginning of words */
 	int m = strlen(haystack);
@@ -74,6 +76,15 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 	int n = strlen(needle);
 	int m = strlen(haystack);
 
+	if (m > MATCH_MAX_LEN || n > MATCH_MAX_LEN) {
+		/*
+		 * Unreasonably large candidate: return no score
+		 * If it is a valid match it will still be returned, it will
+		 * just be ranked below any reasonably sized candidates
+		 */
+		return SCORE_MIN;
+	}
+
 	if (n == m) {
 		/* Since this method can only be called with a haystack which
 		 * matches needle. If the lengths of the strings are equal the
@@ -85,17 +96,8 @@ score_t match_positions(const char *needle, const char *haystack, size_t *positi
 		return SCORE_MAX;
 	}
 
-	if (m > 1024) {
-		/*
-		 * Unreasonably large candidate: return no score
-		 * If it is a valid match it will still be returned, it will
-		 * just be ranked below any reasonably sized candidates
-		 */
-		return SCORE_MIN;
-	}
-
-	char lower_needle[n];
-	char lower_haystack[m];
+	char lower_needle[MATCH_MAX_LEN];
+	char lower_haystack[MATCH_MAX_LEN];
 
 	for (int i = 0; i < n; i++)
 		lower_needle[i] = tolower(needle[i]);

--- a/src/match.c
+++ b/src/match.c
@@ -32,8 +32,6 @@ int has_match(const char *needle, const char *haystack) {
 
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 
-#define MATCH_MAX_LEN 1024
-
 struct match_struct {
 	int needle_len;
 	int haystack_len;

--- a/src/match.h
+++ b/src/match.h
@@ -7,6 +7,8 @@ typedef double score_t;
 #define SCORE_MAX INFINITY
 #define SCORE_MIN -INFINITY
 
+#define MATCH_MAX_LEN 1024
+
 int has_match(const char *needle, const char *haystack);
 score_t match_positions(const char *needle, const char *haystack, size_t *positions);
 score_t match(const char *needle, const char *haystack);

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -36,8 +36,8 @@ static void draw_match(tty_interface_t *state, const char *choice, int selected)
 	char *search = state->last_search;
 
 	int n = strlen(search);
-	size_t positions[n + 1];
-	for (int i = 0; i < n + 1; i++)
+	size_t positions[MATCH_MAX_LEN];
+	for (int i = 0; i < n + 1 && i < MATCH_MAX_LEN; i++)
 		positions[i] = -1;
 
 	score_t score = match_positions(search, choice, &positions[0]);

--- a/test/test_choices.c
+++ b/test/test_choices.c
@@ -135,8 +135,8 @@ TEST test_choices_unicode() {
 }
 
 TEST test_choices_large_input() {
-	int N = 100000;
-	char *strings[N];
+	const int N = 100000;
+	char *strings[100000];
 
 	for(int i = 0; i < N; i++) {
 		asprintf(&strings[i], "%i", i);


### PR DESCRIPTION
This removes all use of variable length arrays across the codebase.

This also splits `match` from `match_positions`, which allows us to use only two rows in `match`, reducing memory to O(m). This also rewrites `match_positions` to use malloc (we only call `match_positions` for the best scored results, so its performance doesn't really matter).

I believe the performance from this is _very slightly_ worse. Probably due to cache lines or alignment or something (what isn't 😆), but I think for now the safety and memory reduction makes this worth it and we'll probably be able to make it up with later improvements.

Based on suggestion by @saagarjha in #131 ❤️