### PR TITLE
Add missing Make dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 fzy
 fzytest
 *.o
+*.d
 config.h
 test/acceptance/vendor/bundle

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION=1.0
 
 CPPFLAGS=-DVERSION=\"${VERSION}\" -D_GNU_SOURCE
-CFLAGS+=-Wall -Wextra -g -std=c99 -O3 -pedantic -Ideps -Werror=vla
+CFLAGS+=-MD -Wall -Wextra -g -std=c99 -O3 -pedantic -Ideps -Werror=vla
 PREFIX?=/usr/local
 MANDIR?=$(PREFIX)/share/man
 BINDIR?=$(PREFIX)/bin
@@ -49,9 +49,11 @@ fmt:
 	clang-format -i src/*.c src/*.h
 
 clean:
-	rm -f fzy test/fzytest src/*.o deps/*/*.o
+	rm -f fzy test/fzytest src/*.o src/*.d deps/*/*.o
 
 veryclean: clean
 	rm -f config.h
 
 .PHONY: test check all clean veryclean install fmt acceptance
+
+-include $(OBJECTS:.o=.d)


### PR DESCRIPTION
Hello

This pull request improves the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built.
Note that this fix follows the best practices for tracking dependencies automatically (through gcc -MD)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html