### PR TITLE
fzy-tmux: Use named pipe for conveying exit code

### DIFF
--- a/contrib/fzy-tmux
+++ b/contrib/fzy-tmux
@@ -23,7 +23,7 @@ main() {
         fatal "Unable to create a temporary directory"
     fi
 
-    mkfifo "${PATH_FIFO_IN}" "${PATH_FIFO_OUT}"
+    mkfifo "${PATH_FIFO_IN}" "${PATH_FIFO_OUT}" "${PATH_FIFO_RET}"
 
     export TMUX=$(_echo "${TMUX}" | cut -d , -f 1,2)
     eval "tmux \


### PR DESCRIPTION
On a couple of occasions I've seen the following error being reported by
the fzy-tmux script:
> head: cannot open '/tmp/tmp.qUbDwrPLxQ/ret' for reading: No such file or directory
> /usr/bin/fzy-tmux: line 41: exit: : numeric argument required

The issue seems to be that PATH_FIFO_RET is not yet created but we
already try to read from it, causing the read to fail. With this change
we use a named pipe which we create before the actual tmux invocation,
preventing this case from happening.

Credit for the fix goes to @zsugabubus.

Closes: #143