### PR TITLE
Add COPR for fzy on RHEL/CentOS/Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Using MacPorts
 
 **[openSUSE](https://software.opensuse.org/package/fzy)**: `zypper in fzy`
 
+**[RHEL/CentOS/Fedora](https://copr.fedorainfracloud.org/coprs/filbranden/fzy/)**: `dnf copr enable filbranden/fzy && dnf install fzy`
+
 ### From source
 
     make


### PR DESCRIPTION
I built fzy for Fedora and RHEL/CentOS on a COPR. Let's add it to the list of supported distributions, with instructions on how to enable and use it.