### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
 dist: trusty
 sudo: false
 language: c
-compiler:
-  - clang
-  - gcc
-os:
-  - linux
-  - osx
+
+matrix:
+   include:
+       - os: linux
+         arch: amd64
+         compiler: clang
+       - os: linux
+         arch: ppc64le
+         compiler: clang
+       - os: osx
+         arch: amd64
+         compiler: clang
+       - os: linux
+         arch: amd64
+         compiler: gcc 
+       - os: linux
+         arch: ppc64le
+         compiler: gcc 
+       - os: osx
+         arch: amd64
+         compiler: gcc 
 script: make && make check
 jobs:
   include:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/fzy/builds/188916613 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!