### PR TITLE
Use defaults if winsize row and col are zero

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -74,7 +74,9 @@ void tty_init(tty_t *tty, const char *tty_filename) {
 
 void tty_getwinsz(tty_t *tty) {
 	struct winsize ws;
-	if (ioctl(fileno(tty->fout), TIOCGWINSZ, &ws) == -1) {
+	if (ioctl(fileno(tty->fout), TIOCGWINSZ, &ws) == -1
+	    || ws.ws_col == 0
+	    || ws.ws_row == 0) {
 		tty->maxwidth = 80;
 		tty->maxheight = 25;
 	} else {


### PR DESCRIPTION
At least for me there is a bug that fzy hangs sometimes. It's because ioctl returns 0, but the winsize is only filled with zeros. Then in https://github.com/jhawthorn/fzy/blob/395a2534aca4a704da7501c5e79268420e41d174/src/fzy.c#L61 you get 0 - 1 or 0 - 2 and num_lines is set to 0xffffffff which in draw gives you an infinite loop.

This uses the default values if ioctl fails or if any value is 0.

If you think it could be formatted in a better way let me know.