### PR TITLE
Add extern "C" to headers when being compiled in c++.

### DIFF
--- a/src/bonus.h
+++ b/src/bonus.h
@@ -3,6 +3,10 @@
 
 #include "../config.h"
 
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 #define ASSIGN_LOWER(v) \
 	['a'] = (v), \
 	['b'] = (v), \
@@ -104,5 +108,9 @@ const size_t bonus_index[256] = {
 };
 
 #define COMPUTE_BONUS(last_ch, ch) (bonus_states[bonus_index[(unsigned char)(ch)]][(unsigned char)(last_ch)])
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/choices.h
+++ b/src/choices.h
@@ -6,6 +6,10 @@
 #include "match.h"
 #include "options.h"
 
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 struct scored_result {
 	score_t score;
 	const char *str;
@@ -37,5 +41,9 @@ const char *choices_get(choices_t *c, size_t n);
 score_t choices_getscore(choices_t *c, size_t n);
 void choices_prev(choices_t *c);
 void choices_next(choices_t *c);
+
+#ifdef __cplusplus 
+}
+#endif
 
 #endif

--- a/src/config.def.h
+++ b/src/config.def.h
@@ -1,3 +1,7 @@
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 #define TTY_COLOR_HIGHLIGHT TTY_COLOR_YELLOW
 
 #define SCORE_GAP_LEADING -0.005
@@ -17,3 +21,7 @@
 #define DEFAULT_NUM_LINES 10
 #define DEFAULT_WORKERS 0
 #define DEFAULT_SHOW_INFO 0
+
+#ifdef __cplusplus 
+}
+#endif

--- a/src/match.h
+++ b/src/match.h
@@ -3,6 +3,10 @@
 
 #include <math.h>
 
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 typedef double score_t;
 #define SCORE_MAX INFINITY
 #define SCORE_MIN -INFINITY
@@ -12,5 +16,9 @@ typedef double score_t;
 int has_match(const char *needle, const char *haystack);
 score_t match_positions(const char *needle, const char *haystack, size_t *positions);
 score_t match(const char *needle, const char *haystack);
+
+#ifdef __cplusplus 
+}
+#endif
 
 #endif

--- a/src/options.h
+++ b/src/options.h
@@ -1,6 +1,10 @@
 #ifndef OPTIONS_H
 #define OPTIONS_H OPTIONS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	int benchmark;
 	const char *filter;
@@ -17,5 +21,9 @@ typedef struct {
 
 void options_init(options_t *options);
 void options_parse(options_t *options, int argc, char *argv[]);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/tty.c
+++ b/src/tty.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/src/tty.h
+++ b/src/tty.h
@@ -1,7 +1,13 @@
 #ifndef TTY_H
 #define TTY_H TTY_H
 
+#include <stddef.h>
+#include <stdio.h>
 #include <termios.h>
+
+#ifdef __cplusplus 
+extern "C" {
+#endif
 
 typedef struct {
 	int fdin;
@@ -56,5 +62,9 @@ void tty_flush(tty_t *tty);
 
 size_t tty_getwidth(tty_t *tty);
 size_t tty_getheight(tty_t *tty);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/tty_interface.h
+++ b/src/tty_interface.h
@@ -5,6 +5,10 @@
 #include "options.h"
 #include "tty.h"
 
+#ifdef __cplusplus 
+extern "C" {
+#endif
+
 #define SEARCH_SIZE_MAX 4096
 
 typedef struct {
@@ -24,5 +28,9 @@ typedef struct {
 
 void tty_interface_init(tty_interface_t *state, tty_t *tty, choices_t *choices, options_t *options);
 int tty_interface_run(tty_interface_t *state);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I've been using `fzy` as a library to do some fuzzy finding in a program I've been working on, this (and a few other small tweaks I'd like to make with your permission) would make it much easier to use in a larger project.

If you're ok with this I'd also like to add:
1. non-global namespacing when being used in c++ (i.e. add open/close namespace tags)
2. Some documentation to the headers.