### PR TITLE
Reduce screen and cursor flickering

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -198,3 +198,11 @@ size_t tty_getwidth(tty_t *tty) {
 size_t tty_getheight(tty_t *tty) {
 	return tty->maxheight;
 }
+
+void tty_hide_cursor(tty_t *tty) {
+	fputs("\x1b[?25l", tty->fout);
+}
+
+void tty_unhide_cursor(tty_t *tty) {
+	fputs("\x1b[?25h", tty->fout);
+}

--- a/src/tty.h
+++ b/src/tty.h
@@ -63,6 +63,9 @@ void tty_flush(tty_t *tty);
 size_t tty_getwidth(tty_t *tty);
 size_t tty_getheight(tty_t *tty);
 
+void tty_hide_cursor(tty_t *tty);
+void tty_unhide_cursor(tty_t *tty);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As the title says, this PR considerably reduces screen and cursor flickering.

Explanation: it avoids calling draw() for **each byte** in a key sequence, making a single call only once the sequence is complete. This way, we reduce the number of calls from 4-5 to just 1, which greatly improves responsiveness and reduces flickering.

Also, I added a few new tty functions to control the cursor visibility: it should be hidden while we're listing entries, and unhidden once we're done.

Hope this helps.