### PR TITLE
Fix: Prevent null dereference and memory leak in choices_search

### DIFF
--- a/src/choices.c
+++ b/src/choices.c
@@ -265,11 +265,14 @@ void choices_search(choices_t *c, const char *search) {
 	choices_reset_search(c);
 
 	struct search_job *job = calloc(1, sizeof(struct search_job));
+	if (job == NULL) {
+		errx(EXIT_FAILURE, "Failed to allocate memory for search_job");
+	}
 	job->search = search;
 	job->choices = c;
 	if (pthread_mutex_init(&job->lock, NULL) != 0) {
-		fprintf(stderr, "Error: pthread_mutex_init failed\n");
-		abort();
+		free(job);
+		errx(EXIT_FAILURE, "pthread_mutex_init failed");
 	}
 	job->workers = calloc(c->worker_count, sizeof(struct worker));
 


### PR DESCRIPTION
### Summary

Hi,
This patch fixes two potential issues in `choices_search()`:

1. **Null pointer dereference**:
   `calloc()` is used to allocate memory for a `struct search_job`, but its return value was not checked before dereferencing. This could lead to a segmentation fault in low-memory situations.

2. **Memory leak**:
   If `pthread_mutex_init()` fails, the previously allocated `job` was not freed before aborting, causing a memory leak.

### Fix

- Adds a NULL check after `calloc()`, with `errx()` on failure.
- Frees the `job` allocation if `pthread_mutex_init()` fails.
- Uses consistent error handling style throughout the function.

### Code

```c
struct search_job *job = calloc(1, sizeof(struct search_job));
if (job == NULL) {
    errx(EXIT_FAILURE, "Failed to allocate memory for search_job");
}

job->search = search;
job->choices = c;

if (pthread_mutex_init(&job->lock, NULL) != 0) {
    free(job);
    errx(EXIT_FAILURE, "pthread_mutex_init failed");
}
```

Thanks for your consideration. I look forward to your feedback!