### PR TITLE
Tighten the `tty` platform abstraction

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -183,6 +183,10 @@ void tty_printf(tty_t *tty, const char *fmt, ...) {
 	va_end(args);
 }
 
+void tty_puts(tty_t *tty, char *s) {
+	fputs(s, tty->fout);
+}
+
 void tty_putc(tty_t *tty, char c) {
 	fputc(c, tty->fout);
 }

--- a/src/tty.h
+++ b/src/tty.h
@@ -57,6 +57,7 @@ void tty_moveup(tty_t *tty, int i);
 void tty_setcol(tty_t *tty, int col);
 
 void tty_printf(tty_t *tty, const char *fmt, ...);
+void tty_puts(tty_t *tty, char *s);
 void tty_putc(tty_t *tty, char c);
 void tty_flush(tty_t *tty);
 

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -113,9 +113,9 @@ static void draw(tty_interface_t *state) {
 		tty_moveup(tty, num_lines + options->show_info);
 
 	tty_setcol(tty, 0);
-	fputs(options->prompt, tty->fout);
+	tty_puts(tty, options->prompt);
 	for (size_t i = 0; i < state->cursor; i++)
-		fputc(state->search[i], tty->fout);
+		tty_putc(tty, state->search[i]);
 	tty_flush(tty);
 }
 


### PR DESCRIPTION
Actually use `tty_putc`, add `tty_puts` for consistency, and don't call `fputc` or `fputs` directly.