### PR TITLE
Adds native Windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,18 @@ MANDIR?=$(PREFIX)/share/man
 BINDIR?=$(PREFIX)/bin
 DEBUGGER?=
 
+ifeq ($(OS),Windows_NT)
+	TTY=tty_win32
+else
+	TTY=tty_posix
+endif
+
 INSTALL=install
 INSTALL_PROGRAM=$(INSTALL)
 INSTALL_DATA=${INSTALL} -m 644
 
 LIBS=-lpthread
-OBJECTS=src/fzy.o src/match.o src/tty.o src/choices.o src/options.o src/tty_interface.o
+OBJECTS=src/fzy.o src/match.o src/$(TTY).o src/choices.o src/options.o src/tty_interface.o
 THEFTDEPS = deps/theft/theft.o deps/theft/theft_bloom.o deps/theft/theft_mt.o deps/theft/theft_hash.o
 TESTOBJECTS=test/fzytest.c test/test_properties.c test/test_choices.c test/test_match.c src/match.o src/choices.o src/options.o $(THEFTDEPS)
 

--- a/src/choices.c
+++ b/src/choices.c
@@ -3,6 +3,9 @@
 #include <string.h>
 #include <pthread.h>
 #include <unistd.h>
+#ifdef _WIN32
+#include <sysinfoapi.h>
+#endif
 #include <errno.h>
 
 #include "options.h"
@@ -111,7 +114,13 @@ void choices_init(choices_t *c, options_t *options) {
 	if (options->workers) {
 		c->worker_count = options->workers;
 	} else {
+	#ifndef _WIN32
 		c->worker_count = (int)sysconf(_SC_NPROCESSORS_ONLN);
+	#else
+		SYSTEM_INFO si;
+		GetSystemInfo(&si);
+		c->worker_count = si.dwNumberOfProcessors;
+	#endif
 	}
 
 	choices_reset_search(c);

--- a/src/fzy.c
+++ b/src/fzy.c
@@ -44,8 +44,7 @@ int main(int argc, char *argv[]) {
 		if (isatty(STDIN_FILENO))
 			choices_fread(&choices, stdin, options.input_delimiter);
 
-		tty_t tty;
-		tty_init(&tty, options.tty_filename);
+		tty_t *tty = tty_init(options.tty_filename);
 
 		if (!isatty(STDIN_FILENO))
 			choices_fread(&choices, stdin, options.input_delimiter);
@@ -57,11 +56,11 @@ int main(int argc, char *argv[]) {
 		if (options.show_info)
 			num_lines_adjustment++;
 
-		if (options.num_lines + num_lines_adjustment > tty_getheight(&tty))
-			options.num_lines = tty_getheight(&tty) - num_lines_adjustment;
+		if (options.num_lines + num_lines_adjustment > tty_getheight(tty))
+			options.num_lines = tty_getheight(tty) - num_lines_adjustment;
 
 		tty_interface_t tty_interface;
-		tty_interface_init(&tty_interface, &tty, &choices, &options);
+		tty_interface_init(&tty_interface, tty, &choices, &options);
 		ret = tty_interface_run(&tty_interface);
 	}
 

--- a/src/tty.h
+++ b/src/tty.h
@@ -3,24 +3,16 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include <termios.h>
 
 #ifdef __cplusplus 
 extern "C" {
 #endif
 
-typedef struct {
-	int fdin;
-	FILE *fout;
-	struct termios original_termios;
-	int fgcolor;
-	size_t maxwidth;
-	size_t maxheight;
-} tty_t;
+typedef struct tty tty_t;
 
 void tty_reset(tty_t *tty);
 void tty_close(tty_t *tty);
-void tty_init(tty_t *tty, const char *tty_filename);
+tty_t *tty_init(const char *tty_filename);
 void tty_getwinsz(tty_t *tty);
 char tty_getchar(tty_t *tty);
 int tty_input_ready(tty_t *tty, long int timeout, int return_on_signal);

--- a/src/tty.h
+++ b/src/tty.h
@@ -35,8 +35,7 @@ void tty_setwrap(tty_t *tty);
 #define TTY_COLOR_NORMAL 9
 
 /* tty_newline
- * Move cursor to the beginning of the next line, clearing to the end of the
- * current line
+ * Move cursor to the beginning of the next line.
  */
 void tty_newline(tty_t *tty);
 

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -21,6 +21,7 @@ static void clear(tty_interface_t *state) {
 	tty_setcol(tty, 0);
 	size_t line = 0;
 	while (line++ < state->options->num_lines + (state->options->show_info ? 1 : 0)) {
+		tty_clearline(tty);
 		tty_newline(tty);
 	}
 	tty_clearline(tty);
@@ -96,12 +97,13 @@ static void draw(tty_interface_t *state) {
 	tty_clearline(tty);
 
 	if (options->show_info) {
-		tty_printf(tty, "\n[%lu/%lu]", choices->available, choices->size);
+		tty_newline(tty);
+		tty_printf(tty, "[%lu/%lu]", choices->available, choices->size);
 		tty_clearline(tty);
 	}
 
 	for (size_t i = start; i < start + num_lines; i++) {
-		tty_printf(tty, "\n");
+		tty_newline(tty);
 		tty_clearline(tty);
 		const char *choice = choices_get(choices, i);
 		if (choice) {

--- a/src/tty_posix.c
+++ b/src/tty_posix.c
@@ -175,7 +175,7 @@ void tty_setwrap(tty_t *tty) {
 }
 
 void tty_newline(tty_t *tty) {
-	tty_printf(tty, "%c%cK\n", 0x1b, '[');
+	tty_printf(tty, "\n");
 }
 
 void tty_clearline(tty_t *tty) {

--- a/src/tty_win32.c
+++ b/src/tty_win32.c
@@ -1,0 +1,201 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <signal.h>
+#include <errno.h>
+
+#include "tty.h"
+
+#include "../config.h"
+
+struct conmode {
+	DWORD in, out;
+};
+
+struct tty {
+	HANDLE hin;
+	HANDLE hout;
+	struct conmode original_conmode;
+	int fgcolor;
+	size_t maxwidth;
+	size_t maxheight;
+};
+
+void tty_reset(tty_t *tty) {
+	SetConsoleMode(tty->hin, tty->original_conmode.in);
+	SetConsoleMode(tty->hout, tty->original_conmode.out);
+}
+
+void tty_close(tty_t *tty) {
+	tty_reset(tty);
+	CloseHandle(tty->hin);
+	CloseHandle(tty->hout);
+	free(tty);
+}
+
+static void handle_sigwinch(int sig){
+	(void)sig;
+}
+
+tty_t *tty_init(const char *tty_filename) {
+	tty_t *tty = malloc(sizeof(*tty));
+
+	tty->hin = CreateFileA("CONIN$", GENERIC_READ | GENERIC_WRITE, 0, 0, OPEN_EXISTING, 0, 0);
+	if (tty->hin == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "Failed to open CONIN$: error %ld\n", GetLastError());
+		exit(EXIT_FAILURE);
+	}
+
+	tty->hout = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE, 0, 0, OPEN_EXISTING, 0, 0);
+	if (tty->hout == INVALID_HANDLE_VALUE) {
+		fprintf(stderr, "Failed to open CONOUT$: error %ld\n", GetLastError());
+		exit(EXIT_FAILURE);
+	}
+
+	if (GetConsoleMode(tty->hin, &tty->original_conmode.in) == 0) {
+		fprintf(stderr, "Failed to get console mode for CONIN$: error %ld\n", GetLastError());
+		exit(EXIT_FAILURE);
+	}
+
+	if (GetConsoleMode(tty->hout, &tty->original_conmode.out) == 0) {
+		fprintf(stderr, "Failed to get console mode for CONOUT$: error %ld\n", GetLastError());
+		exit(EXIT_FAILURE);
+	}
+
+	DWORD raw_in = tty->original_conmode.in;
+	DWORD raw_out = tty->original_conmode.out;
+
+    // Raw modes
+    raw_in &= ~ENABLE_PROCESSED_INPUT;
+    raw_in &= ~ENABLE_LINE_INPUT;
+    raw_in &= ~ENABLE_ECHO_INPUT;
+    raw_out |= ENABLE_PROCESSED_OUTPUT;
+
+    // VT modes
+	raw_in  |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+	raw_out |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	raw_out |= DISABLE_NEWLINE_AUTO_RETURN;
+
+	if (SetConsoleMode(tty->hin, raw_in) == 0) {
+		fprintf(stderr, "Failed to set raw console mode for CONIN$: error %ld\n", GetLastError());
+	}
+	if (SetConsoleMode(tty->hout, raw_out) == 0) {
+		fprintf(stderr, "Failed to set raw console mode for CONOUT$: error %ld\n", GetLastError());
+	}
+
+	tty_getwinsz(tty);
+
+	tty_setnormal(tty);
+
+	//signal(SIGWINCH, handle_sigwinch);
+
+	return tty;
+}
+
+void tty_getwinsz(tty_t *tty) {
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+	if (GetConsoleScreenBufferInfo(tty->hout, &csbi) == 0) {
+		tty->maxwidth = 80;
+		tty->maxheight = 25;
+	} else {
+		tty->maxwidth = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+		tty->maxheight = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	}
+}
+
+char tty_getchar(tty_t *tty) {
+	char ch;
+	unsigned long size = 0;
+	if (ReadConsoleA(tty->hin, &ch, 1, &size, NULL) == 0) {
+		fprintf(stderr, "ReadConsoleA: error %ld\n", GetLastError());
+		exit(EXIT_FAILURE);
+	} else if (size == 0) {
+		/* EOF */
+		exit(EXIT_FAILURE);
+	} else {
+		return ch;
+	}
+}
+
+int tty_input_ready(tty_t *tty, long int timeout, int return_on_signal) {
+	return WaitForSingleObject(tty->hin, timeout) == 0;
+}
+
+static void tty_sgr(tty_t *tty, int code) {
+	tty_printf(tty, "%c%c%im", 0x1b, '[', code);
+}
+
+void tty_setfg(tty_t *tty, int fg) {
+	if (tty->fgcolor != fg) {
+		tty_sgr(tty, 30 + fg);
+		tty->fgcolor = fg;
+	}
+}
+
+void tty_setinvert(tty_t *tty) {
+	tty_sgr(tty, 7);
+}
+
+void tty_setunderline(tty_t *tty) {
+	tty_sgr(tty, 4);
+}
+
+void tty_setnormal(tty_t *tty) {
+	tty_sgr(tty, 0);
+	tty->fgcolor = 9;
+}
+
+void tty_setnowrap(tty_t *tty) {
+	tty_printf(tty, "%c%c?7l", 0x1b, '[');
+}
+
+void tty_setwrap(tty_t *tty) {
+	tty_printf(tty, "%c%c?7h", 0x1b, '[');
+}
+
+void tty_newline(tty_t *tty) {
+	tty_printf(tty, "\r\n");
+}
+
+void tty_clearline(tty_t *tty) {
+	tty_printf(tty, "%c%cK", 0x1b, '[');
+}
+
+void tty_setcol(tty_t *tty, int col) {
+	tty_printf(tty, "%c%c%iG", 0x1b, '[', col + 1);
+}
+
+void tty_moveup(tty_t *tty, int i) {
+	tty_printf(tty, "%c%c%iA", 0x1b, '[', i);
+}
+
+void tty_printf(tty_t *tty, const char *fmt, ...) {
+	va_list args;
+	va_start(args, fmt);
+	char buf[1024];
+	WriteConsoleA(tty->hout, buf, vsnprintf(buf, sizeof(buf), fmt, args), 0, 0);
+	va_end(args);
+}
+
+void tty_puts(tty_t *tty, char *s) {
+	WriteConsoleA(tty->hout, s, strlen(s), 0, 0);
+}
+
+void tty_putc(tty_t *tty, char c) {
+	WriteConsoleA(tty->hout, &c, 1, 0, 0);
+}
+
+void tty_flush(tty_t *tty) {
+	(void)tty;
+}
+
+size_t tty_getwidth(tty_t *tty) {
+	return tty->maxwidth;
+}
+
+size_t tty_getheight(tty_t *tty) {
+	return tty->maxheight;
+}


### PR DESCRIPTION
This is a concise patch bringing simple native Windows support to `fzy`.

I have tried to keep the changes to absolute minimum and refrained from including fixups in this PR.

It may be interesting to diff `tty_posix.c` with `tty_win32.c` for a quick overview of the port.

What I'm most unsure about is if you'll find the conditional build OK. I went through several alternatives before settling on renaming `tty.c` and the conditional in the `Makefile`. For compatibility with other forks it may be desirable to keep `tty.c` and change the non-Windows branch in the `Makefile` to `TTY=tty`. Or to keep a `tty.c` with the following contents:
```
#ifdef __linux__
#include "tty_posix.c"
#elif _WIN32
#include "tty_win32.c"
#endif
```

Let me know if you're otherwise fine with the changes but would like them integrated in the build differently. I can prepare it how you are most comfortable.

Needs testing on POSIX-ish. Tested on Windows 11 and functional. Wants further enhancements to mitigate flickering (will do that in a separate PR: #201 ).

747e26d anticipates #199 and implements `tty_puts`.

Commit message:
```
choices.c: Win32 processor count
tty.h: Semantic change for tty_newline: No longer clears, and serves as platform LF/CRLF
tty_interface.c: Prior hardcoded '\n' are now calls to tty_newline. Additionally, prior calls to tty_newline is now preceded by tty_clearline
tty.c -> tty_posix.c: The only change to tty.c (other than renaming) is that tty_newline no longer clears the line
tty_win32.c: Simple windows tty support. Considerations:
  - Uses ASCII versions of CreateFile, ReadConsole, and WriteConsole. For future reference consult {Create,Read,Write}{Console,File}{A/W/Input}
  - tty_init doesn't implement tty_filename argument on Windows, only CONIN$/CONOUT$
  - Buffered IO: Buffer size (setvbuf) not set. FILE* vs. HANDLE (for conmode)
  - SIGWINCH not handled. For future reference, see ReadConsoleInput + WINDOW_BUFFER_SIZE_EVENT
Makefile: OS check
```