### PR TITLE
Fix screen and cursor flickering

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -160,6 +160,14 @@ void tty_setwrap(tty_t *tty) {
 	tty_printf(tty, "%c%c?7h", 0x1b, '[');
 }
 
+void tty_hidecursor(tty_t *tty) {
+  tty_printf(tty, "\x1b[" "?25l");
+}
+
+void tty_showcursor(tty_t *tty) {
+  tty_printf(tty, "\x1b[" "?25h");
+}
+
 void tty_newline(tty_t *tty) {
 	tty_printf(tty, "%c%cK\n", 0x1b, '[');
 }

--- a/src/tty.h
+++ b/src/tty.h
@@ -32,6 +32,9 @@ void tty_setnormal(tty_t *tty);
 void tty_setnowrap(tty_t *tty);
 void tty_setwrap(tty_t *tty);
 
+void tty_hidecursor(tty_t *tty);
+void tty_showcursor(tty_t *tty);
+
 #define TTY_COLOR_BLACK 0
 #define TTY_COLOR_RED 1
 #define TTY_COLOR_GREEN 2

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -91,6 +91,7 @@ static void draw(tty_interface_t *state) {
 		}
 	}
 
+	tty_hidecursor(tty);
 	tty_setcol(tty, 0);
 	tty_printf(tty, "%s%s", options->prompt, state->search);
 	tty_clearline(tty);
@@ -102,11 +103,11 @@ static void draw(tty_interface_t *state) {
 
 	for (size_t i = start; i < start + num_lines; i++) {
 		tty_printf(tty, "\n");
-		tty_clearline(tty);
 		const char *choice = choices_get(choices, i);
 		if (choice) {
 			draw_match(state, choice, i == choices->selection);
 		}
+		tty_clearline(tty);
 	}
 
 	if (num_lines + options->show_info)
@@ -117,6 +118,7 @@ static void draw(tty_interface_t *state) {
 	for (size_t i = 0; i < state->cursor; i++)
 		fputc(state->search[i], tty->fout);
 	tty_flush(tty);
+	tty_showcursor(tty);
 }
 
 static void update_search(tty_interface_t *state) {

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -117,8 +117,8 @@ static void draw(tty_interface_t *state) {
 	fputs(options->prompt, tty->fout);
 	for (size_t i = 0; i < state->cursor; i++)
 		fputc(state->search[i], tty->fout);
-	tty_flush(tty);
 	tty_showcursor(tty);
+	tty_flush(tty);
 }
 
 static void update_search(tty_interface_t *state) {


### PR DESCRIPTION
Terminal redrawing should never clear before drawing
  - Instead set cursor to starting point, (over)write, then erase-from-cursor-to-end-of-line after outputting each line, and erase-to-end-of-screen after last output

Also hide cursor while redrawing and show again after